### PR TITLE
Spread out header components

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -154,7 +154,7 @@ const Header = () => (
       className="h-5 w-5"
       viewBox="0 0 20 20"
       fill="#f3f3f3"
-      className="animate-bounce cursor-pointer h-8 w-8 mt-4 md:mt-8"
+      className="animate-bounce cursor-pointer h-8 w-8 mt-auto"
       onClick={() =>
         window.scrollTo({
           top: window.innerHeight,


### PR DESCRIPTION
How does this look on your computers? Biggest changes is adding `mt-auto` on the logos so it moves away from the title/apply elements. Could do the same for the bouncing arrow if we want the move the logos back towards the center a little

Also removed redundant div in `<Header>`